### PR TITLE
- add unsubscribe capability

### DIFF
--- a/lib/presence.js
+++ b/lib/presence.js
@@ -15,6 +15,7 @@ Presence.prototype._events = {
     'xmpp.presence': 'sendPresence',
     'xmpp.presence.subscribe': 'subscribe',
     'xmpp.presence.subscribed': 'setSubscribed',
+    'xmpp.presence.unsubscribe': 'setUnsubscribe',
     'xmpp.presence.unsubscribed': 'setUnsubscribed',
     'xmpp.presence.get': 'get',
     'xmpp.presence.offline': 'setOffline',
@@ -27,6 +28,10 @@ Presence.prototype.subscribe = function(data) {
 
 Presence.prototype.setSubscribed = function(data) {
     this.subscription(data, 'subscribed')
+}
+
+Presence.prototype.setUnsubscribe = function(data) {
+    this.subscription(data, 'unsubscribe')
 }
 
 Presence.prototype.setUnsubscribed = function(data) {

--- a/test/lib/presence.js
+++ b/test/lib/presence.js
@@ -214,6 +214,37 @@ describe('Presence', function() {
             )
         })
 
+        describe('Unsubscribe stanzas', function() {
+
+            it('Returns error when no \'to\' value provided', function(done) {
+                xmpp.once('stanza', function() {
+                    done('Unexpected outgoing stanza')
+                })
+                socket.once('xmpp.error.client', function(data) {
+                    data.type.should.equal('modify')
+                    data.condition.should.equal('client-error')
+                    data.description.should.equal('Missing \'to\' key')
+                    data.request.should.eql({})
+                    xmpp.removeAllListeners('stanza')
+                    done()
+                })
+                socket.send('xmpp.presence.unsubscribe', {})
+            })
+
+            it('Can send unsubscribe stanza', function(done) {
+                    var to = 'juliet@example.com/balcony'
+                    xmpp.once('stanza', function(stanza) {
+                        stanza.is('presence').should.be.true
+                        stanza.attrs.to.should.equal(to)
+                        stanza.attrs.type.should.equal('unsubscribe')
+                        stanza.attrs.from.should.equal(manager.jid)
+                        done()
+                    })
+                    socket.send('xmpp.presence.unsubscribe', { to: to })
+                }
+            )
+        })
+
         describe('Unsubscribed stanzas', function() {
 
             it('Returns error when no \'to\' value provided', function(done) {


### PR DESCRIPTION
http://xmpp.org/rfcs/rfc3921.html#sub §6.4

It's usefull when we want to remove user from roster like described in http://xmpp.org/rfcs/rfc3921.html#int-remove

I also make a PR @ xmpp-ftw-demo to add this feature into docs
