### PR TITLE
Fix stanza catching issue

### DIFF
--- a/lib/xmpp.js
+++ b/lib/xmpp.js
@@ -201,6 +201,7 @@ Xmpp.prototype.catchTracked = function(stanza) {
     var id = stanza.root().attr('id')
     if (!id || !this.tracking[id]) return false
     if (this.tracking[id].jid &&
+        stanza.attr('from') &&
         (-1 === this.tracking[id].jid.indexOf(stanza.attr('from')))) {
         // Ignore stanza its an ID spoof!
         return true

--- a/test/lib/xmpp.js
+++ b/test/lib/xmpp.js
@@ -231,7 +231,27 @@ describe('FTW', function() {
             })
             
         })
-        
+
+        describe('No response \'from\' address', function() {
+
+            it('Accepts server JID response', function(done) {
+                var id = '10'
+                var outgoingStanza = ltx.parse(
+                    '<iq id="' + id + '"/>'
+                )
+                ftw.trackId(outgoingStanza, function(stanza) {
+                    should.not.exist(stanza.attrs.from)
+                    stanza.attrs.id.should.equal(id)
+                    done()
+                })
+                var incomingStanza = outgoingStanza.clone()
+                delete incomingStanza.attrs.from
+                delete incomingStanza.attrs.to
+                ftw.catchTracked(incomingStanza).should.be.true
+            })
+
+        })
+    
     })
 
 })


### PR DESCRIPTION
When I send a roster get request to prosody (and possibly) other servers then the **from** attribute does not appear to be returned. For example,

**outgoing:**

``` xml
<iq from="lloyd@buddycloud.org" type="get" id="a236af25-f083-4ea7-957b-ec1d58d69290">
    <query xmlns="jabber:iq:roster"/>
</iq>
```

**response:**

``` xml
<iq id="a236af25-f083-4ea7-957b-ec1d58d69290" type="result" to="lloyd@buddycloud.org/laptop" xmlns:stream="http://etherx.jabber.org/streams">
    <query ver="39" xmlns="jabber:iq:roster">
        <item jid="abmargb@buddycloud.org" subscription="both"/>
        <item jid="chatftw1@ch3kr.de" ask="subscribe" subscription="from" name="Juan"/>
        <item jid="me@matthewwi....
```

In this case the stanza ID spoofing protection is stopping the response from getting back to the requester. Therefore I'm suggesting that if a response stanza has no **from** address then we assume the response it coming from the user's server.
