### PR TITLE
fix for stack overload due to multiple 'offline' events

### DIFF
--- a/lib/xmpp.js
+++ b/lib/xmpp.js
@@ -48,7 +48,7 @@ Xmpp.prototype.registerXmppEvents = function() {
         self.online()
     })
     this.client.on('stanza', function(stanza) { self.handleStanza(stanza) })
-    this.client.on('offline', function() {
+    this.client.once('offline', function() {
         self.handleError('disconnected')
         self.logout()
     })


### PR DESCRIPTION
Simple fix for multiple `offline` events leading to error - `"RangeError: Maximum call stack size exceeded"`
